### PR TITLE
Use absolute values for fork counts

### DIFF
--- a/main.c
+++ b/main.c
@@ -73,13 +73,13 @@ int main(int argc, char **argv) {
                         memory = (unsigned int)(atoi(optarg));
                         break;
                 case 'b':
-                        busy_forks = (unsigned int)(atoi(optarg));
+                        busy_forks = (unsigned int)(abs(atoi(optarg)));
                         break;
                 case 't':
                         run_time = (unsigned int)(atoi(optarg));
                         break;
                 case 'f':
-                        forks = (unsigned int)(atoi(optarg));
+                        forks = (unsigned int)(abs(atoi(optarg)));
                         break;
                 case 'h':
                         usage(*argv);


### PR DESCRIPTION
This prevent a segmentation fault when `bambam` is called with negative
values for the fork parameters, as in:

  `./bambam -f -1 -b -1`